### PR TITLE
Fixes for missing text in comment attributes and corrections to SEND pattern.

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -98,8 +98,8 @@ IN_OR_OUT = {
 	"mal:request": "IN",
 	"mal:progress": "IN",
 	"mal:submit": "IN",
+	"mal:send": "IN",
 
-	"mal:send": "OUT",
 	"mal:update": "OUT",
 	"mal:acknowledgement": "OUT",
 	"mal:response": "OUT",

--- a/helper.js
+++ b/helper.js
@@ -114,7 +114,7 @@ OMMITED_NODE_TYPES = ["mal:specification", "mal:capabilitySet", "mal:documentati
 	"mal:item", "mal:type", "mal:extends", "mal:field", "mal:extraInformation",
 	// IP related
 	"mal:invoke", "mal:acknowledgement", "mal:response", "mal:request", "mal:progress", "mal:update", "mal:submit",
-	"mal:publishNotify"
+	"mal:publishNotify", "mal:send"
 	// COM related
 	, "com:object", "com:event"
 	, "com:objectType", "com:sourceObject", "com:relatedObject"

--- a/helper.js
+++ b/helper.js
@@ -201,6 +201,9 @@ function treeElementName(element) {
 }
 
 function format_line_breaks(text) {
+	if (text == null) {
+		return null
+	}
 	return text.replace(/\n/g, "\n<br/>")
 }
 


### PR DESCRIPTION
Some missing text, e.g. a non-existent comment attribute for composite fields, caused a TypeError which prevented the whole composite structure from being shown.

Also the pattern direction for SEND has been corrected (IN instead of OUT). Node attachment for SEND is now handled the same way as for all other IPs.